### PR TITLE
Add Monte Carlo endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,11 @@
 import asyncio
-from dataclasses import dataclass
 from urllib import response
 from fastapi import FastAPI
-import random
 from contextlib import asynccontextmanager
+
 from sim import get_data
-from models import Day, Data, Weather
+from models import Day
+from monte_carlo import simulate_mc_loop, state as mc_state
 
 
 #from rocket import get_rocket
@@ -14,6 +14,7 @@ from models import Day, Data, Weather
 async def lifespan(app: FastAPI):
     # Kick off the continuous simulation loop as soon as the app starts
     asyncio.create_task(simulate_loop())
+    asyncio.create_task(simulate_mc_loop())
     yield
 
 app = FastAPI(lifespan=lifespan)
@@ -40,6 +41,12 @@ def get_status():
     # Clients call this once per second (or however often you like)
     return state
 
+
+@app.get("/MC")
+def get_mc():
+    return mc_state
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)
+

--- a/monte_carlo.py
+++ b/monte_carlo.py
@@ -1,0 +1,17 @@
+import asyncio
+import random
+
+state = {"estimate": 0.0, "points": 0}
+
+async def simulate_mc_loop():
+    global state
+    inside = 0
+    total = 0
+    while True:
+        for _ in range(1000):
+            x, y = random.random(), random.random()
+            total += 1
+            if x * x + y * y <= 1.0:
+                inside += 1
+        state = {"estimate": 4 * inside / total, "points": total}
+        await asyncio.sleep(1)


### PR DESCRIPTION
## Summary
- simulate pi estimation with Monte Carlo in `monte_carlo.py`
- start the Monte Carlo loop in `main.py` and expose `/MC` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ee84602c83219530053aaedf4848