### PR TITLE
Fix missing current forecast handling

### DIFF
--- a/weather.py
+++ b/weather.py
@@ -29,7 +29,11 @@ def select_forecasts(lat: float, lon: float, *, timeout=10) -> list[Weather]:
     timeseries.sort(key=ts_dt)
     now_utc = datetime.now(ZoneInfo("UTC"))
 
-    current = max((ts for ts in timeseries if ts_dt(ts) <= now_utc), key=ts_dt)
+    current = max(
+        (ts for ts in timeseries if ts_dt(ts) <= now_utc),
+        key=ts_dt,
+        default=timeseries[0],
+    )
     first_after = lambda moment: next(ts for ts in timeseries if ts_dt(ts) >= moment)
 
     plus1 = first_after(now_utc + timedelta(hours=1))


### PR DESCRIPTION
## Summary
- avoid ValueError in weather.select_forecasts if there is no past forecast timestamp

## Testing
- `python -m py_compile weather.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ef8d46588321a44d759d767855d7