### PR TITLE
Suppress tank geometry warnings

### DIFF
--- a/monte_carlo.py
+++ b/monte_carlo.py
@@ -4,11 +4,23 @@ from zoneinfo import ZoneInfo
 
 import numpy as np
 import pandas as pd
-from rocketpy import Environment, Rocket, Flight, LiquidMotor, CylindricalTank, MassFlowRateBasedTank, Fluid as RPFluid
+from rocketpy import (
+    Environment,
+    Rocket,
+    Flight,
+    LiquidMotor,
+    CylindricalTank,
+    MassFlowRateBasedTank,
+    Fluid as RPFluid,
+)
 from pyfluids import FluidsList, Mixture, Input, Fluid as PyFluid
+
+import contextlib
+import io
 
 from models import Day, Data, Weather, FlightData
 from weather import construct_environment
+import os
 
 # ---------------------------------------------------------------------------
 # Read input parameters exactly like sim.py
@@ -118,11 +130,12 @@ def worker_mc(env: Environment, inclination: float, heading: float) -> Data:
         analysis_parameters["ox_tank_length"],
         spherical_caps=False,
     )
-    n2_geom = CylindricalTank(
-        analysis_parameters["n2_tank_radius"],
-        analysis_parameters["n2_tank_length"],
-        spherical_caps=True,
-    )
+    with open(os.devnull, "w") as devnull, contextlib.redirect_stdout(devnull):
+        n2_geom = CylindricalTank(
+            analysis_parameters["n2_tank_radius"],
+            analysis_parameters["n2_tank_length"],
+            spherical_caps=True,
+        )
 
     oxidizer = RPFluid(name="N2O", density=N2O.density)
     fuel = RPFluid(name="fuel", density=fuel_mix.density)

--- a/sim.py
+++ b/sim.py
@@ -4,12 +4,21 @@ import zoneinfo
 import pandas as pd
 import numpy as np
 import datetime 
-from rocketpy import Environment, Rocket, Flight, LiquidMotor, CylindricalTank, MassFlowRateBasedTank, Fluid as RPFluid
+from rocketpy import (
+    Environment,
+    Rocket,
+    Flight,
+    LiquidMotor,
+    CylindricalTank,
+    MassFlowRateBasedTank,
+    Fluid as RPFluid,
+)
 from pyfluids import FluidsList, Mixture, Input, Fluid as PyFluid
 from zoneinfo import ZoneInfo
 from models import Day, Data, Weather, FlightData
 import os
 import contextlib
+import io
 import csv
 from time import process_time
 
@@ -139,7 +148,8 @@ def worker(env: Environment) -> Data:
     # Now build the geometries with plain floats
     fuel_geom = CylindricalTank(fuel_radius, fuel_length, spherical_caps=False)
 
-    n2_geom   = CylindricalTank(n2_radius,   n2_length,   spherical_caps=True)
+    with open(os.devnull, "w") as devnull, contextlib.redirect_stdout(devnull):
+        n2_geom = CylindricalTank(n2_radius, n2_length, spherical_caps=True)
     # Unpack the raw floats
     ox_radius = analysis_parameters["ox_tank_radius"]
     ox_length = analysis_parameters["ox_tank_length"]


### PR DESCRIPTION
## Summary
- silence noisy rocketpy warning messages from cylindrical tank creation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f4f20bac8321ba143e690a32f398