### PR TITLE
Fix timezone warning in weather environment setup

### DIFF
--- a/weather.py
+++ b/weather.py
@@ -80,7 +80,11 @@ def construct_environment(
 
     # Load the climatology dataset only once instead of once per forecast.
     ds = xr.open_dataset(climatology_file)
-    ts = np.datetime64(launch_time.astimezone(ZoneInfo("UTC")))
+    # numpy.datetime64 does not keep timezone information. Convert the launch
+    # time to UTC and drop the timezone before creating the numpy timestamp to
+    # avoid warnings about timezone handling.
+    ts_utc = launch_time.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
+    ts = np.datetime64(ts_utc)
 
     for w in weather_list:
         T_obs   = w.temperature      # °C


### PR DESCRIPTION
## Summary
- avoid timezone warnings when converting launch times to `numpy.datetime64`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849f79d2d8883218b2860183e563a35