### PR TITLE
Fix dataset caching to stabilize memory usage

### DIFF
--- a/weather.py
+++ b/weather.py
@@ -15,9 +15,11 @@ USER_AGENT = "myApp/0.1 you@example.com"    # required by api.met.no
 _ds_cache = {}
 
 def _get_dataset(path: str) -> xr.Dataset:
+    """Return a cached xarray.Dataset with data loaded into memory."""
     ds = _ds_cache.get(path)
     if ds is None:
-        ds = xr.open_dataset(path)
+        with xr.open_dataset(path) as tmp:
+            ds = tmp.load()
         _ds_cache[path] = ds
     return ds
 


### PR DESCRIPTION
## Summary
- fully load environment datasets into memory to avoid xarray caching growth
- cleanup environment objects after each simulation step

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_684daaf202048321827b1c57b2693abe